### PR TITLE
Fix cond clause when time now equals to expiration date.

### DIFF
--- a/lib/plugs/verification.ex
+++ b/lib/plugs/verification.ex
@@ -21,7 +21,7 @@ defmodule Jwt.Plugs.Verification do
     cond do
       ignore_token_expiration -> {:ok, claims}
       now > expiration_date -> @expired_token_error
-      now < expiration_date -> {:ok, claims}
+      now <= expiration_date -> {:ok, claims}
     end
   end
 

--- a/test/httpcacheclient_test.exs
+++ b/test/httpcacheclient_test.exs
@@ -4,7 +4,6 @@ defmodule CachingHttpClientTest do
   require Logger
 
   @validtesturl "https://accounts.google.com/.well-known/openid-configuration"
-  @invalidtesturl "https://www.google.com"
   @testcache Jwt.Cache.Ets
 
   setup do


### PR DESCRIPTION
This change is to validate a condition that was never being covered (when the date is equal to the expiration date).
