### PR TITLE
Improve library testability

### DIFF
--- a/lib/firebasecerts.ex
+++ b/lib/firebasecerts.ex
@@ -5,7 +5,8 @@ defmodule Jwt.FirebaseCerts.PublicKey do
   def getfor(id), do: fetch(id)
 
   defp fetch(id) do
-    @httpclient.get!(@certs_url)
+    @certs_url
+    |> @httpclient.get!()
     |> get_response_body
     |> extract_public_key_for_id(id)
   end
@@ -18,7 +19,7 @@ defmodule Jwt.FirebaseCerts.PublicKey do
   defp extract_public_key_for_id({:error, _}, _id), do: nil
 
   defp extract_public_key_for_id({:ok, body}, id) do
-    parsed = Jason.decode!(body, %{})
+    parsed = Jason.decode!(body)
 
     cert = parsed[id]
 

--- a/lib/googlecerts.ex
+++ b/lib/googlecerts.ex
@@ -26,7 +26,7 @@ defmodule Jwt.GoogleCerts.PublicKey do
     do: {:error, body}
 
   defp extract_certificates_url({:ok, body}) do
-    parsed = Jason.decode!(body, %{})
+    parsed = Jason.decode!(body)
 
     case parsed[@jwt_uri_in_discovery] do
       nil -> {:notfounderror, "No JWT url found"}
@@ -42,7 +42,7 @@ defmodule Jwt.GoogleCerts.PublicKey do
   defp extract_public_key_for_id({:error, _}, _id), do: nil
 
   defp extract_public_key_for_id({:ok, body}, id) do
-    parsed = Jason.decode!(body, %{})
+    parsed = Jason.decode!(body)
 
     key = List.first(Enum.filter(parsed["keys"], fn key -> key["kid"] == id end))
 

--- a/lib/jwt.ex
+++ b/lib/jwt.ex
@@ -1,6 +1,4 @@
 defmodule Jwt do
-  @google_certs_api Application.get_env(:jwt, :googlecerts, Jwt.GoogleCerts.PublicKey)
-  @firebase_certs_api Application.get_env(:jwt, :firebasecerts, Jwt.FirebaseCerts.PublicKey)
   @invalid_token_error {:error, "Invalid token"}
   @invalid_signature_error {:error, "Invalid signature"}
   @key_id "kid"
@@ -34,13 +32,12 @@ defmodule Jwt do
 
   defp _verify(_, _), do: @invalid_token_error
 
-  defp extract_key_id(header), do: Jason.decode!(header, %{})[@key_id]
+  defp extract_key_id(header), do: Jason.decode!(header)[@key_id]
 
   defp retrieve_cert_exp_and_mod_for_key(key_id) do
-    @google_certs_api.getfor(key_id)
-    |> case do
+    case google_certs_api().getfor(key_id) do
       {:ok, cert_data} -> {:ok, cert_data}
-      {:notfounderror, _} -> @firebase_certs_api.getfor(key_id)
+      {:notfounderror, _} -> firebase_certs_api().getfor(key_id)
       _ -> @invalid_token_error
     end
   end
@@ -49,11 +46,14 @@ defmodule Jwt do
     msg = header_b64 <> "." <> claims_b64
 
     case :crypto.verify(:rsa, :sha256, msg, signature, [exponent, modulus]) do
-      true -> {:ok, Jason.decode!(Base.url_decode64!(claims_b64, padding: false), %{})}
+      true -> {:ok, claims_b64 |> Base.url_decode64!(padding: false) |> Jason.decode!()}
       false -> @invalid_signature_error
     end
   end
 
   defp verify_signature({:error, _}, _, _, _), do: @invalid_token_error
   defp verify_signature(_, _, _, _), do: @invalid_signature_error
+
+  defp google_certs_api, do: Application.get_env(:jwt, :googlecerts, Jwt.GoogleCerts.PublicKey)
+  defp firebase_certs_api, do: Application.get_env(:jwt, :firebasecerts, Jwt.FirebaseCerts.PublicKey)
 end

--- a/lib/jwt_display.ex
+++ b/lib/jwt_display.ex
@@ -5,21 +5,21 @@ defmodule Jwt.Display do
   ## Examples
 
       iex> Jwt.Display.display("eyJhbGciOiJSUzI1NiIsImtpZCI6IjEwZWZiZjlmOWEzZThlYzVlN2RmYTc5NjFkNzFlMmU0YmZkYTI0MzUifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhdWQiOiIzNDczODQ1NjIxMTMtcmRtNnNsZG0xbWIzOGs0dW1yY28zcDhsN3I1aGcwazUuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMTAzNjE0MDAyNDQ4NzEyMjU0MTQiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiYXpwIjoiMzQ3Mzg0NTYyMTEzLXIyOHBqZDB1Yzlwb2Y1Y20xcDBubmwyNXM5N2o4dXFwLmFwcHMuZ29vZ2xldXNlcmNvbnRlbnQuY29tIiwiaGQiOiJieXRlYWJ5dGUubmV0IiwiZW1haWwiOiJhbGVqYW5kcm8ubWV6Y3VhQGJ5dGVhYnl0ZS5uZXQiLCJpYXQiOjE0NzMyMjU4NjQsImV4cCI6MTQ3MzIyOTQ2NCwibmFtZSI6IkFsZWphbmRybyBNZXpjdWEiLCJwaWN0dXJlIjoiaHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tLy1mSUpUN0cydVozRS9BQUFBQUFBQUFBSS9BQUFBQUFBQUFRWS9KdkNWbUZIWG5yOC9zOTYtYy9waG90by5qcGciLCJnaXZlbl9uYW1lIjoiQWxlamFuZHJvIiwiZmFtaWx5X25hbWUiOiJNZXpjdWEiLCJsb2NhbGUiOiJlbiJ9.Kc90u_gtZyhq6glw6UoYQSInZx9r16uqrRO7g50x17JWH7VkyAZrh3sfjdBYpGtDNJjDRBKSxuinpDjpyfiCp3-XAqqOUWqziyYvkV4-CdQvNhcnUQFXjjx_CzNiiEi5PRPCHhX4ajidet1NH4Me02S17gwOZiaZfed1BMWQuQ_7Hf2RsX5FID1xqOpcaaouMFcrqQFmdBIbcstHamWxs9D83c4JpOsioNOMb6-LBinzOg7qdxr1D4NvHD6VSXBTbyXiOBjK2elLU1iCz_Hz_BH-R1IYCdTRr5PczRWdSCgoTdZ7ds1nTTglfuXlGNbaEhhzsFxX8OCR4uNK6vbWXQ")
-      {:ok, {:claims, 
+      {:ok, {:claims,
           %{
-              "aud" => "347384562113-rdm6sldm1mb38k4umrco3p8l7r5hg0k5.apps.googleusercontent.com", 
-              "azp" => "347384562113-r28pjd0uc9pof5cm1p0nnl25s97j8uqp.apps.googleusercontent.com", 
-              "email" => "alejandro.mezcua@byteabyte.net", 
-              "email_verified" => true, 
-              "exp" => 1473229464, 
-              "family_name" => "Mezcua", 
-              "given_name" => "Alejandro", 
-              "hd" => "byteabyte.net", 
-              "iat" => 1473225864, 
-              "iss" => "https://accounts.google.com", 
-              "locale" => "en", 
-              "name" => "Alejandro Mezcua", 
-              "picture" => "https://lh3.googleusercontent.com/-fIJT7G2uZ3E/AAAAAAAAAAI/AAAAAAAAAQY/JvCVmFHXnr8/s96-c/photo.jpg", 
+              "aud" => "347384562113-rdm6sldm1mb38k4umrco3p8l7r5hg0k5.apps.googleusercontent.com",
+              "azp" => "347384562113-r28pjd0uc9pof5cm1p0nnl25s97j8uqp.apps.googleusercontent.com",
+              "email" => "alejandro.mezcua@byteabyte.net",
+              "email_verified" => true,
+              "exp" => 1473229464,
+              "family_name" => "Mezcua",
+              "given_name" => "Alejandro",
+              "hd" => "byteabyte.net",
+              "iat" => 1473225864,
+              "iss" => "https://accounts.google.com",
+              "locale" => "en",
+              "name" => "Alejandro Mezcua",
+              "picture" => "https://lh3.googleusercontent.com/-fIJT7G2uZ3E/AAAAAAAAAAI/AAAAAAAAAQY/JvCVmFHXnr8/s96-c/photo.jpg",
               "sub" => "110361400244871225414"
               }}}
 
@@ -39,6 +39,6 @@ defmodule Jwt.Display do
          _claims_b64,
          _signature_b64
        ]) do
-    {:claims, Jason.decode!(claims, %{})}
+    {:claims, Jason.decode!(claims)}
   end
 end

--- a/lib/mockcerts.ex
+++ b/lib/mockcerts.ex
@@ -1,0 +1,13 @@
+defmodule Jwt.Mockcerts.PublicKey do
+  def getfor(_id) do
+    Jwt.PemParser.extract_exponent_and_modulus_from_pem_cert(certificate())
+  end
+
+  def private_key do
+    Application.get_env(:jwt, :mock_private_key)
+  end
+
+  def certificate do
+    Application.get_env(:jwt, :mock_certificate)
+  end
+end

--- a/lib/plugs/verification.ex
+++ b/lib/plugs/verification.ex
@@ -1,12 +1,12 @@
 defmodule Jwt.Plugs.Verification do
-  @expired_token_error {:error, "Expired token."}
   @timeutils Application.get_env(:jwt, :timeutils, Jwt.TimeUtils)
   @five_minutes 5 * 60
 
   def default_options(), do: %{:ignore_token_expiration => false, :time_window => @five_minutes}
 
   def verify_token(token, opts) do
-    verify_signature(token)
+    token
+    |> verify_signature()
     |> verify_expiration(opts)
   end
 
@@ -20,10 +20,10 @@ defmodule Jwt.Plugs.Verification do
 
     cond do
       ignore_token_expiration -> {:ok, claims}
-      now > expiration_date -> @expired_token_error
+      now > expiration_date -> {:error, "Expired token."}
       now <= expiration_date -> {:ok, claims}
     end
   end
 
-  defp verify_expiration({:error, _}, _opts), do: @expired_token_error
+  defp verify_expiration({:error, _} = error, _opts), do: error
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Jwt.Mixfile do
   def project do
     [
       app: :jwt,
-      version: "0.6.0",
+      version: "0.6.1",
       elixir: "~> 1.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
@@ -15,7 +15,7 @@ defmodule Jwt.Mixfile do
 
   def application do
     [
-      applications: [:logger, :httpoison, :cowboy, :plug, :timex],
+      extra_applications: [:logger, :httpoison, :cowboy, :plug, :timex],
       mod: {Jwt.Cache.Ets, []},
       env: [plug_cookie_name: "googlejwt"]
     ]

--- a/test/jwt_filter_claims_plug_test.exs
+++ b/test/jwt_filter_claims_plug_test.exs
@@ -111,7 +111,7 @@ defmodule JwtFilterClaimsPlugTest do
 
   defp build_conn_with_claims() do
     conn = conn(:get, "/protected")
-    Plug.Conn.assign(conn, :jwtclaims, Jason.decode!(Base.url_decode64!(@rawclaims), %{}))
+    Plug.Conn.assign(conn, :jwtclaims, @rawclaims |> Base.url_decode64!() |> Jason.decode!())
   end
 
   defp assert401(conn) do


### PR DESCRIPTION
## Motivation

It is important to allow for library users to correctly mock irreproducible behavior, but keeping the rest of the functionality available for testing.

Use cases of this library will very likely involve user authentication, so making sure the library is in good shape to make this kind of flow testable is imperative.

## Proposed solution

- Leverage existing mock for Google and Firebase modules for certificates fetching, but without the [non-recommended](https://hexdocs.pm/elixir/1.12/library-guidelines.html#avoid-compile-time-application-configuration) compile-time configuration reading.