### PR TITLE
drop stash dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,6 @@ defmodule Jwt.Mixfile do
       {:ex_doc, only: :dev, runtime: false, github: "elixir-lang/ex_doc"},
       {:cowboy, "~> 2.8"},
       {:plug, "~> 1.10"},
-      {:stash, "~> 1.0"},
       {:timex, "~> 3.6.1"}
     ]
   end


### PR DESCRIPTION
## What are you trying to accomplish?
Updating the project to Elixir 1.15, this dependency is breaking the tests. Since it has no utility, as checked with @brosquinha, we're removing it from the code base.

## What approach did you choose and why?
Simply removing it from the dependencies.

## What should reviewers focus on?